### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+beautifulsoup4==4.6.0
+boilerpipy==0.2.5
+certifi==2018.4.16
+chardet==3.0.4
+cssselect==1.0.3
+idna==2.7
+lxml==4.2.1
+recordtype==1.1
+requests==2.19.0
+urllib3==1.23
+urlparse2==1.1.1


### PR DESCRIPTION
while building this a user have to manually install all the dependencies which can be a bit a tedious task to do.
So I have added all the dependencies into a single file i.e requirements.txt.
Now doing `pip install -r requirements.txt` will install all the the requirements to run this tool.   